### PR TITLE
detect AskUserQuestion tool_use as Waiting instead of Processing

### DIFF
--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -4,4 +4,4 @@ mod status;
 
 pub use model::{AgentType, Session, SessionStatus, SessionsResponse};
 pub use parser::{parse_session_file, convert_dir_name_to_path, convert_path_to_dir_name, get_sessions, get_sessions_internal, cleanup_stale_status_entries};
-pub use status::{determine_status, status_sort_priority, has_tool_use, has_tool_result, is_local_slash_command, is_interrupted_request};
+pub use status::{determine_status, status_sort_priority, has_tool_use, has_tool_result, is_local_slash_command, is_interrupted_request, is_waiting_for_user_input};

--- a/src-tauri/src/session/parser.rs
+++ b/src-tauri/src/session/parser.rs
@@ -9,7 +9,7 @@ use once_cell::sync::Lazy;
 
 use crate::agent::AgentProcess;
 use super::model::{AgentType, Session, SessionStatus, SessionsResponse, JsonlMessage};
-use super::status::{determine_status, has_tool_use, has_tool_result, is_local_slash_command, is_interrupted_request};
+use super::status::{determine_status, has_tool_use, has_tool_result, is_local_slash_command, is_interrupted_request, is_waiting_for_user_input};
 
 /// Track previous status for each session to detect transitions
 static PREVIOUS_STATUS: Lazy<Mutex<HashMap<String, SessionStatus>>> = Lazy::new(|| Mutex::new(HashMap::new()));
@@ -483,6 +483,7 @@ pub fn parse_session_file(
     let mut last_has_tool_result = false;
     let mut last_is_local_command = false;
     let mut last_is_interrupted = false;
+    let mut last_is_user_input_tool = false;
     let mut found_status_info = false;
     let mut is_compacting = false;
 
@@ -537,13 +538,14 @@ pub fn parse_session_file(
                             last_has_tool_result = has_tool_result(c);
                             last_is_local_command = is_local_slash_command(c);
                             last_is_interrupted = is_interrupted_request(c);
+                            last_is_user_input_tool = is_waiting_for_user_input(c);
                             found_status_info = true;
 
                             // Enhanced logging with content preview
                             let content_preview = get_content_preview(c);
                             debug!(
-                                "Found status info: type={:?}, role={:?}, has_tool_use={}, has_tool_result={}, is_local_cmd={}, is_interrupted={}, content={}",
-                                last_msg_type, last_role, last_has_tool_use, last_has_tool_result, last_is_local_command, last_is_interrupted, content_preview
+                                "Found status info: type={:?}, role={:?}, has_tool_use={}, has_tool_result={}, is_local_cmd={}, is_interrupted={}, is_user_input={}, content={}",
+                                last_msg_type, last_role, last_has_tool_use, last_has_tool_result, last_is_local_command, last_is_interrupted, last_is_user_input_tool, content_preview
                             );
                         }
                     }
@@ -594,13 +596,14 @@ pub fn parse_session_file(
             last_has_tool_result,
             last_is_local_command,
             last_is_interrupted,
+            last_is_user_input_tool,
             file_recently_modified,
         )
     };
 
     debug!(
-        "Status determination: type={:?}, tool_use={}, tool_result={}, local_cmd={}, interrupted={}, recent={}, compacting={}, file_age={:.1}s -> {:?}",
-        last_msg_type, last_has_tool_use, last_has_tool_result, last_is_local_command, last_is_interrupted, file_recently_modified, is_compacting, file_age_secs.unwrap_or(-1.0), status
+        "Status determination: type={:?}, tool_use={}, tool_result={}, local_cmd={}, interrupted={}, user_input={}, recent={}, compacting={}, file_age={:.1}s -> {:?}",
+        last_msg_type, last_has_tool_use, last_has_tool_result, last_is_local_command, last_is_interrupted, last_is_user_input_tool, file_recently_modified, is_compacting, file_age_secs.unwrap_or(-1.0), status
     );
 
     // Extract project name from path

--- a/src-tauri/src/session/status.rs
+++ b/src-tauri/src/session/status.rs
@@ -14,6 +14,33 @@ pub fn has_tool_use(content: &serde_json::Value) -> bool {
     }
 }
 
+/// Check if all tool_use blocks in content are user-input tools (e.g., AskUserQuestion).
+/// These tools block on user input and should be treated as Waiting, not Processing.
+/// Returns false if any tool_use has no name or an unrecognized name.
+pub fn is_waiting_for_user_input(content: &serde_json::Value) -> bool {
+    let user_input_tools = ["AskUserQuestion"];
+
+    if let serde_json::Value::Array(arr) = content {
+        let tool_use_blocks: Vec<_> = arr.iter()
+            .filter(|item| {
+                item.get("type")
+                    .and_then(|t| t.as_str())
+                    .map(|t| t == "tool_use")
+                    .unwrap_or(false)
+            })
+            .collect();
+
+        !tool_use_blocks.is_empty() && tool_use_blocks.iter().all(|item| {
+            item.get("name")
+                .and_then(|n| n.as_str())
+                .map(|name| user_input_tools.contains(&name))
+                .unwrap_or(false) // unnamed tool_use -> not a user-input tool
+        })
+    } else {
+        false
+    }
+}
+
 /// Check if message content contains a tool_result block
 pub fn has_tool_result(content: &serde_json::Value) -> bool {
     if let serde_json::Value::Array(arr) = content {
@@ -108,11 +135,15 @@ pub fn determine_status(
     _has_tool_result: bool,
     is_local_command: bool,
     is_interrupted: bool,
+    is_user_input_tool: bool,
     file_recently_modified: bool,
 ) -> SessionStatus {
     match last_msg_type {
         Some("assistant") => {
-            if has_tool_use {
+            if has_tool_use && is_user_input_tool {
+                // Tool like AskUserQuestion - waiting for user input
+                SessionStatus::Waiting
+            } else if has_tool_use {
                 // Tool is executing - could take seconds or minutes
                 SessionStatus::Processing
             } else if file_recently_modified {

--- a/src-tauri/src/tests/session_tests.rs
+++ b/src-tauri/src/tests/session_tests.rs
@@ -1,7 +1,7 @@
 use crate::session::{
     AgentType, SessionStatus, parse_session_file, convert_dir_name_to_path, convert_path_to_dir_name,
     determine_status, status_sort_priority, has_tool_use, has_tool_result, is_local_slash_command,
-    is_interrupted_request, cleanup_stale_status_entries, get_sessions_internal
+    is_interrupted_request, is_waiting_for_user_input, cleanup_stale_status_entries, get_sessions_internal
 };
 use crate::agent::AgentProcess;
 use serde_json::json;
@@ -218,6 +218,46 @@ fn test_is_local_slash_command() {
 }
 
 #[test]
+fn test_is_waiting_for_user_input() {
+    // Single AskUserQuestion -> Waiting
+    assert!(is_waiting_for_user_input(&json!([
+        {"type": "tool_use", "id": "1", "name": "AskUserQuestion"}
+    ])));
+
+    // Multiple AskUserQuestion -> Waiting
+    assert!(is_waiting_for_user_input(&json!([
+        {"type": "tool_use", "id": "1", "name": "AskUserQuestion"},
+        {"type": "tool_use", "id": "2", "name": "AskUserQuestion"}
+    ])));
+
+    // Mixed: AskUserQuestion + Bash -> Processing (not all are user-input)
+    assert!(!is_waiting_for_user_input(&json!([
+        {"type": "tool_use", "id": "1", "name": "AskUserQuestion"},
+        {"type": "tool_use", "id": "2", "name": "Bash"}
+    ])));
+
+    // Unnamed tool_use + AskUserQuestion -> Processing (unnamed is not safe)
+    assert!(!is_waiting_for_user_input(&json!([
+        {"type": "tool_use", "id": "1", "name": "AskUserQuestion"},
+        {"type": "tool_use", "id": "2"}
+    ])));
+
+    // Non-user-input tool only
+    assert!(!is_waiting_for_user_input(&json!([
+        {"type": "tool_use", "id": "1", "name": "Read"}
+    ])));
+
+    // No tool_use at all
+    assert!(!is_waiting_for_user_input(&json!([
+        {"type": "text", "text": "hello"}
+    ])));
+
+    // Non-array content
+    assert!(!is_waiting_for_user_input(&json!("string")));
+    assert!(!is_waiting_for_user_input(&json!(null)));
+}
+
+#[test]
 fn test_determine_status_assistant_with_tool_use() {
     // Assistant message with tool_use -> always Processing (tool could run for minutes)
     let status = determine_status(
@@ -226,6 +266,7 @@ fn test_determine_status_assistant_with_tool_use() {
         false, // has_tool_result
         false, // is_local_command
         false, // is_interrupted
+        false, // is_user_input_tool
         false, // file_recently_modified
     );
     assert!(matches!(status, SessionStatus::Processing));
@@ -237,9 +278,22 @@ fn test_determine_status_assistant_with_tool_use() {
         false,
         false,
         false,
+        false,
         true,
     );
     assert!(matches!(status, SessionStatus::Processing));
+
+    // AskUserQuestion tool_use -> Waiting (waiting for user input)
+    let status = determine_status(
+        Some("assistant"),
+        true,  // has_tool_use
+        false,
+        false,
+        false,
+        true,  // is_user_input_tool
+        false,
+    );
+    assert!(matches!(status, SessionStatus::Waiting));
 }
 
 #[test]
@@ -252,12 +306,14 @@ fn test_determine_status_assistant_text_only() {
         false,
         false,
         false,
+        false,
     );
     assert!(matches!(status, SessionStatus::Waiting));
 
     // With recent file activity, text-only assistant = Processing (still streaming/compacting)
     let status = determine_status(
         Some("assistant"),
+        false,
         false,
         false,
         false,
@@ -277,12 +333,14 @@ fn test_determine_status_user_message() {
         false, // not a local command
         false, // is_interrupted
         false,
+        false,
     );
     assert!(matches!(status, SessionStatus::Thinking));
 
     // User message with recent file activity -> Thinking
     let status = determine_status(
         Some("user"),
+        false,
         false,
         false,
         false,
@@ -299,6 +357,7 @@ fn test_determine_status_user_message() {
         true, // is_local_command
         false,
         false,
+        false,
     );
     assert!(matches!(status, SessionStatus::Waiting));
 
@@ -309,6 +368,7 @@ fn test_determine_status_user_message() {
         false,
         false,
         true, // is_interrupted
+        false,
         false,
     );
     assert!(matches!(status, SessionStatus::Waiting));
@@ -324,6 +384,7 @@ fn test_determine_status_user_with_tool_result() {
         false,
         false,
         false,
+        false,
     );
     assert!(matches!(status, SessionStatus::Thinking));
 
@@ -332,6 +393,7 @@ fn test_determine_status_user_with_tool_result() {
         Some("user"),
         false,
         true,
+        false,
         false,
         false,
         true,
@@ -348,6 +410,7 @@ fn test_determine_status_unknown_type() {
         false,
         false,
         false,
+        false,
         true,
     );
     assert!(matches!(status, SessionStatus::Processing));
@@ -355,6 +418,7 @@ fn test_determine_status_unknown_type() {
     // Unknown message type, file stale -> Waiting
     let status = determine_status(
         None,
+        false,
         false,
         false,
         false,


### PR DESCRIPTION
## Summary

When Claude's last message contains an `AskUserQuestion` tool_use, the session status was shown as "Processing". Since the session is waiting for user input, this PR reports "Waiting" instead.

## Changes

- Detect messages where all tool_use blocks are user-input tools
- Return `Waiting` in that case
- Mixed or unknown tool_use blocks remain `Processing` (covered by tests)
- Add tests (8 cases)

## Note

This currently hardcodes Claude's `AskUserQuestion` in a shared status layer. If other agents introduce similar input-blocking tools, this logic may need to move closer to the agent/provider layer.